### PR TITLE
Fix click event triggering after revert scroll

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -498,7 +498,7 @@ export default class ScrollBooster {
 
         this.events.click = (event) => {
             const state = this.getState();
-            if (Math.abs(Math.max(state.dragOffset.x, state.dragOffset.y)) > CLICK_EVENT_THRESHOLD_PX) {
+            if (Math.max(Math.abs(state.dragOffset.x), Math.abs(state.dragOffset.y)) > CLICK_EVENT_THRESHOLD_PX) {
                 event.preventDefault();
                 event.stopPropagation();
             }


### PR DESCRIPTION
The maximum drag must be for both absolute offsets.
Now if the direction is 'horizontal' or 'vertical' and the dragOffset is negative the maximum value is 0 and stop events not work for revert scrolling. 