### PR TITLE
Add onWheel callback for swap axes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ export default class ScrollBooster {
      * @param {Boolean} options.emulateScroll - enables mousewheel emulation
      * @param {Function} options.onClick - click handler
      * @param {Function} options.onUpdate - state update handler
+     * @param {Function} options.onWheel - wheel handler
      * @param {Function} options.shouldScroll - predicate to allow or disable scroll
      */
     constructor(options = {}) {
@@ -66,6 +67,7 @@ export default class ScrollBooster {
             pointerDownPreventDefault: true,
             onClick() {},
             onUpdate() {},
+            onWheel() {},
             shouldScroll() {
                 return true;
             },
@@ -470,6 +472,7 @@ export default class ScrollBooster {
         };
 
         this.events.wheel = (event) => {
+            const state = this.getState();
             if (!this.props.emulateScroll) {
                 return;
             }
@@ -479,6 +482,8 @@ export default class ScrollBooster {
 
             this.scrollOffset.x = -event.deltaX;
             this.scrollOffset.y = -event.deltaY;
+
+            this.props.onWheel(state, event);
 
             this.startAnimationLoop();
 


### PR DESCRIPTION
To create behaviour like on this site https://canals-amsterdam.nl/  (mouse wheel vertical but scroll by Y axis), I need add deltaY to scrollOffset.x
This advise https://github.com/ilyashubin/scrollbooster/issues/19 didn't help me, because `position.x` always 0.

Instead of adding an option for this, I created callback  function on wheel event. So in my code i can replace it like this:
```
SBRef.current = new ScrollBooster({
  viewport: rootRef.current,
  content: contentRef.current,
  direction: 'horizontal',
  emulateScroll: true,
  scrollMode: 'native',
  onWheel: (state, event) => {
    SBRef.current.scrollOffset.x = -event.deltaY
  }
})
```

I'm not sure about how to set offset, like example above or:
```
...
this.props.onWheel(state, event, this);
...
onWheel: (state, event, object) => {
  object.scrollOffset.x = -event.deltaY
}
```
I don't see problems in PR approach.