### PR TITLE
Lock scroll when dragged horizontally/vertically

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ friction | Number | 0.05 | Scroll friction factor - how fast scrolling stops aft
 bounceForce | Number | 0.1 | Elastic bounce effect factor
 emulateScroll | Boolean | false | Enables mouse wheel/trackpad emulation inside viewport
 pointerDownPreventDefault | Boolean | true | Prevent default `mousedown`/`touchstart` event (scroll window while dragging on mobile devices)
+lockScrollOnDragDirection | String | false | Detect drag direction and either prevent default `mousedown`/`touchstart` event or lock content scroll. Could be 'horizontal' or 'vertical'
+lockScrollOnDragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag direction detection
 onUpdate | Function | noop | Handler function to perform actual scrolling. Receives scrolling state object with coordinates
 onClick | Function | noop | Click handler function. Here you can, for example, prevent default event for click on links. Receives object with scrolling metrics and event object. Calls after each `click` in scrollable area
 shouldScroll | Function | noop | Function to permit or disable scrolling. Receives object with scrolling state and event object. Calls on `pointerdown` (mousedown, touchstart) in scrollable area. You can return `true` or `false` to enable or disable scrolling
@@ -79,7 +81,7 @@ const sb = new ScrollBooster({
   textSelection: false,
   emulateScroll: true,
   onUpdate: (state) => {
-    // state contains useful metrics: position, dragOffset, isDragging, isMoving, borderCollision
+    // state contains useful metrics: position, dragOffset, dragAngle, isDragging, isMoving, borderCollision
     // you can control scroll rendering manually without 'scrollMethod' option:
     content.style.transform = `translate(
       ${-state.position.x}px,

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ pointerMode | String | 'all' | Specify pointer type. Supported values - 'touch' 
 friction | Number | 0.05 | Scroll friction factor - how fast scrolling stops after pointer release
 bounceForce | Number | 0.1 | Elastic bounce effect factor
 emulateScroll | Boolean | false | Enables mouse wheel/trackpad emulation inside viewport
+preventDefaultOnEmulateScroll | String | false | Prevents horizontal or vertical default when `emulateScroll` is enabled (eg. useful to prevent horizontal trackpad gestures while enabling vertical scrolling). Could be 'horizontal' or 'vertical'.
 pointerDownPreventDefault | Boolean | true | Prevent default `mousedown`/`touchstart` event (scroll window while dragging on mobile devices)
 lockScrollOnDragDirection | String | false | Detect drag direction and either prevent default `mousedown`/`touchstart` event or lock content scroll. Could be 'horizontal' or 'vertical'
 DragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag direction detection

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ bounceForce | Number | 0.1 | Elastic bounce effect factor
 emulateScroll | Boolean | false | Enables mouse wheel/trackpad emulation inside viewport
 pointerDownPreventDefault | Boolean | true | Prevent default `mousedown`/`touchstart` event (scroll window while dragging on mobile devices)
 lockScrollOnDragDirection | String | false | Detect drag direction and either prevent default `mousedown`/`touchstart` event or lock content scroll. Could be 'horizontal' or 'vertical'
-lockScrollOnDragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag direction detection
+DragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag direction detection
 onUpdate | Function | noop | Handler function to perform actual scrolling. Receives scrolling state object with coordinates
 onClick | Function | noop | Click handler function. Here you can, for example, prevent default event for click on links. Receives object with scrolling metrics and event object. Calls after each `click` in scrollable area
 shouldScroll | Function | noop | Function to permit or disable scrolling. Receives object with scrolling state and event object. Calls on `pointerdown` (mousedown, touchstart) in scrollable area. You can return `true` or `false` to enable or disable scrolling

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ emulateScroll | Boolean | false | Enables mouse wheel/trackpad emulation inside 
 preventDefaultOnEmulateScroll | String | false | Prevents horizontal or vertical default when `emulateScroll` is enabled (eg. useful to prevent horizontal trackpad gestures while enabling vertical scrolling). Could be 'horizontal' or 'vertical'.
 pointerDownPreventDefault | Boolean | true | Prevent default `mousedown`/`touchstart` event (scroll window while dragging on mobile devices)
 lockScrollOnDragDirection | String | false | Detect drag direction and either prevent default `mousedown`/`touchstart` event or lock content scroll. Could be 'horizontal' or 'vertical'
-DragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag direction detection
+dragDirectionTolerance | Number | 40 | Tolerance for horizontal or vertical drag detection
 onUpdate | Function | noop | Handler function to perform actual scrolling. Receives scrolling state object with coordinates
 onClick | Function | noop | Click handler function. Here you can, for example, prevent default event for click on links. Receives object with scrolling metrics and event object. Calls after each `click` in scrollable area
 shouldScroll | Function | noop | Function to permit or disable scrolling. Receives object with scrolling state and event object. Calls on `pointerdown` (mousedown, touchstart) in scrollable area. You can return `true` or `false` to enable or disable scrolling

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,8 @@ export default class ScrollBooster {
             inputsFocus: true,
             emulateScroll: false,
             pointerDownPreventDefault: true,
+            lockScrollOnDragDirection: false, // 'vertical', 'horizontal'
+            lockScrollOnDragDirectionTolerance: 40,
             onClick() {},
             onUpdate() {},
             onWheel() {},
@@ -96,6 +98,7 @@ export default class ScrollBooster {
         this.velocity = { ...START_COORDINATES };
         this.dragStartPosition = { ...START_COORDINATES };
         this.dragOffset = { ...START_COORDINATES };
+        this.clientOffset = { ...START_COORDINATES };
         this.dragPosition = { ...START_COORDINATES };
         this.targetPosition = { ...START_COORDINATES };
         this.scrollOffset = { ...START_COORDINATES };
@@ -350,6 +353,7 @@ export default class ScrollBooster {
             isDragging: !!(this.dragOffset.x || this.dragOffset.y),
             position: { x: -this.position.x, y: -this.position.y },
             dragOffset: this.dragOffset,
+            dragAngle: this.getDragAngle(this.clientOffset.x, this.clientOffset.y),
             borderCollision: {
                 left: this.position.x >= this.edgeX.to,
                 right: this.position.x <= this.edgeX.from,
@@ -357,6 +361,26 @@ export default class ScrollBooster {
                 bottom: this.position.y <= this.edgeY.from,
             },
         };
+    }
+
+    /**
+     * Get drag angle (up: 180, left: -90, right: 90, down: 0)
+     */
+    getDragAngle(x, y) {
+        return Math.round(Math.atan2(x, y) * (180 / Math.PI));
+    }
+
+    /**
+     * Get drag direction (horizontal or vertical)
+     */
+    getDragDirection(angle, tolerance) {
+        const absAngle = Math.abs(90 - Math.abs(angle));
+
+        if (absAngle <= 90 - tolerance) {
+            return 'horizontal';
+        } else {
+            return 'vertical';
+        }
     }
 
     /**
@@ -377,6 +401,8 @@ export default class ScrollBooster {
      */
     handleEvents() {
         const dragOrigin = { x: 0, y: 0 };
+        const clientOrigin = { x: 0, y: 0 };
+        let dragDirection = null;
         let wheelTimer = null;
         let isTouch = false;
 
@@ -385,14 +411,41 @@ export default class ScrollBooster {
                 return;
             }
 
-            const pageX = isTouch ? event.touches[0].pageX : event.pageX;
-            const pageY = isTouch ? event.touches[0].pageY : event.pageY;
+            const eventData = isTouch ? event.touches[0] : event;
+            const { pageX, pageY, clientX, clientY } = eventData;
 
             this.dragOffset.x = pageX - dragOrigin.x;
             this.dragOffset.y = pageY - dragOrigin.y;
 
-            this.dragPosition.x = this.dragStartPosition.x + this.dragOffset.x;
-            this.dragPosition.y = this.dragStartPosition.y + this.dragOffset.y;
+            this.clientOffset.x = clientX - clientOrigin.x;
+            this.clientOffset.y = clientY - clientOrigin.y;
+
+            if (
+                (Math.abs(this.clientOffset.x) > 5 && !dragDirection) ||
+                (Math.abs(this.clientOffset.y) > 5 && !dragDirection)
+            ) {
+                dragDirection = this.getDragDirection(
+                    this.getDragAngle(this.clientOffset.x, this.clientOffset.y),
+                    this.props.lockScrollOnDragDirectionTolerance
+                );
+            }
+
+            // prevent scroll if not expected scroll direction
+            if (this.props.lockScrollOnDragDirection) {
+                if (dragDirection === this.props.lockScrollOnDragDirection && isTouch) {
+                    this.dragPosition.x = this.dragStartPosition.x + this.dragOffset.x;
+                    this.dragPosition.y = this.dragStartPosition.y + this.dragOffset.y;
+                } else if (!isTouch) {
+                    this.dragPosition.x = this.dragStartPosition.x + this.dragOffset.x;
+                    this.dragPosition.y = this.dragStartPosition.y + this.dragOffset.y;
+                } else {
+                    this.dragPosition.x = this.dragStartPosition.x;
+                    this.dragPosition.y = this.dragStartPosition.y;
+                }
+            } else {
+                this.dragPosition.x = this.dragStartPosition.x + this.dragOffset.x;
+                this.dragPosition.y = this.dragStartPosition.y + this.dragOffset.y;
+            }
         };
 
         this.events.pointerdown = (event) => {
@@ -453,22 +506,36 @@ export default class ScrollBooster {
 
             dragOrigin.x = pageX;
             dragOrigin.y = pageY;
+
+            clientOrigin.x = clientX;
+            clientOrigin.y = clientY;
+
             this.dragStartPosition.x = this.position.x;
             this.dragStartPosition.y = this.position.y;
 
             setDragPosition(event);
             this.startAnimationLoop();
+
             if (this.props.pointerDownPreventDefault) {
                 event.preventDefault();
             }
         };
 
         this.events.pointermove = (event) => {
+            // prevent default scroll if scroll direction is locked
+            if (
+                this.props.lockScrollOnDragDirection &&
+                dragDirection === this.props.lockScrollOnDragDirection &&
+                event.cancelable
+            ) {
+                event.preventDefault();
+            }
             setDragPosition(event);
         };
 
         this.events.pointerup = () => {
             this.isDragging = false;
+            dragDirection = null;
         };
 
         this.events.wheel = (event) => {
@@ -519,13 +586,13 @@ export default class ScrollBooster {
         this.events.resize = () => this.updateMetrics();
 
         this.props.viewport.addEventListener('mousedown', this.events.pointerdown);
-        this.props.viewport.addEventListener('touchstart', this.events.pointerdown);
+        this.props.viewport.addEventListener('touchstart', this.events.pointerdown, { passive: false });
         this.props.viewport.addEventListener('click', this.events.click);
-        this.props.viewport.addEventListener('wheel', this.events.wheel);
+        this.props.viewport.addEventListener('wheel', this.events.wheel, { passive: false });
         this.props.viewport.addEventListener('scroll', this.events.scroll);
         this.props.content.addEventListener('load', this.events.contentLoad, true);
         window.addEventListener('mousemove', this.events.pointermove);
-        window.addEventListener('touchmove', this.events.pointermove);
+        window.addEventListener('touchmove', this.events.pointermove, { passive: false });
         window.addEventListener('mouseup', this.events.pointerup);
         window.addEventListener('touchend', this.events.pointerup);
         window.addEventListener('resize', this.events.resize);

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export default class ScrollBooster {
             preventDefaultOnEmulateScroll: false, // 'vertical', 'horizontal'
             pointerDownPreventDefault: true,
             lockScrollOnDragDirection: false, // 'vertical', 'horizontal'
-            DragDirectionTolerance: 40,
+            dragDirectionTolerance: 40,
             onClick() {},
             onUpdate() {},
             onWheel() {},
@@ -428,7 +428,7 @@ export default class ScrollBooster {
             ) {
                 dragDirection = this.getDragDirection(
                     this.getDragAngle(this.clientOffset.x, this.clientOffset.y),
-                    this.props.DragDirectionTolerance
+                    this.props.dragDirectionTolerance
                 );
             }
 
@@ -564,7 +564,7 @@ export default class ScrollBooster {
                 this.props.preventDefaultOnEmulateScroll &&
                 this.getDragDirection(
                     this.getDragAngle(-event.deltaX, -event.deltaY),
-                    this.props.DragDirectionTolerance
+                    this.props.dragDirectionTolerance
                 ) === this.props.preventDefaultOnEmulateScroll
             ) {
                 event.preventDefault();

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ export default class ScrollBooster {
             textSelection: false,
             inputsFocus: true,
             emulateScroll: false,
+            preventDefaultOnEmulateScroll: false, // 'vertical', 'horizontal'
             pointerDownPreventDefault: true,
             lockScrollOnDragDirection: false, // 'vertical', 'horizontal'
             DragDirectionTolerance: 40,
@@ -420,6 +421,7 @@ export default class ScrollBooster {
             this.clientOffset.x = clientX - clientOrigin.x;
             this.clientOffset.y = clientY - clientOrigin.y;
 
+            // get dragDirection if offset threshold is reached
             if (
                 (Math.abs(this.clientOffset.x) > 5 && !dragDirection) ||
                 (Math.abs(this.clientOffset.y) > 5 && !dragDirection)
@@ -556,7 +558,17 @@ export default class ScrollBooster {
 
             clearTimeout(wheelTimer);
             wheelTimer = setTimeout(() => (this.isScrolling = false), 80);
-            event.preventDefault();
+
+            // get (trackpad) scrollDirection and prevent default events
+            if (
+                this.props.preventDefaultOnEmulateScroll &&
+                this.getDragDirection(
+                    this.getDragAngle(-event.deltaX, -event.deltaY),
+                    this.props.DragDirectionTolerance
+                ) === this.props.preventDefaultOnEmulateScroll
+            ) {
+                event.preventDefault();
+            }
         };
 
         this.events.scroll = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ export default class ScrollBooster {
             emulateScroll: false,
             pointerDownPreventDefault: true,
             lockScrollOnDragDirection: false, // 'vertical', 'horizontal'
-            lockScrollOnDragDirectionTolerance: 40,
+            DragDirectionTolerance: 40,
             onClick() {},
             onUpdate() {},
             onWheel() {},
@@ -426,7 +426,7 @@ export default class ScrollBooster {
             ) {
                 dragDirection = this.getDragDirection(
                     this.getDragAngle(this.clientOffset.x, this.clientOffset.y),
-                    this.props.lockScrollOnDragDirectionTolerance
+                    this.props.DragDirectionTolerance
                 );
             }
 


### PR DESCRIPTION
Improve the interaction for mobile devices:
If `lockScrollOnDragDirection` is set to 'horizontal' and a horizontal drag is detected, default touch events will be prevented; if a vertical drag is detected, the drag position won't be updated.

Vice versa if `lockScrollOnDragDirection` is set to 'vertical', eventhough I'm not sure if there is a use case for this.

Goal is to increase UX for mobile devices since the `pointerDownPreventDefault` prop alone wasn't enough and the page jumps around if a scrollable element is being dragged (somewhat referencing #28)

[Codesandbox Demo](https://codesandbox.io/s/scollbooster-pr-example-gr2td?file=/index.html) 